### PR TITLE
Fix POM version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
     
     <groupId>com.proofpoint.cloudmanagement.service</groupId>
     <artifactId>cloud-management</artifactId>
-    <version>1.3-SNAPSHOT</version>
+    <version>1.4-SNAPSHOT</version>
 
     <inceptionYear>2011</inceptionYear>
 


### PR DESCRIPTION
Sonatype OSS already contains a built version of 1.3. I have no idea where
that was built, but there doesn't appear to be any trace of it. Moving onto
1.4-SNAPSHOT
